### PR TITLE
Fix typo in french translation

### DIFF
--- a/spec/Coduo/PHPHumanizer/DateTimeSpec.php
+++ b/spec/Coduo/PHPHumanizer/DateTimeSpec.php
@@ -139,13 +139,13 @@ class DateTimeSpec extends ObjectBehavior
     function it_humanizes_precise_difference_between_dates_for_fr_locale()
     {
         $examples = array(
-            array("2014-04-26 13:00:00", "2014-04-26 12:58:15", '1 minute, 45 secondes il y\'a'),
-            array("2014-04-26 13:00:00", "2014-04-26 11:20:00", '1 heure, 40 minutes il y\'a'),
+            array("2014-04-26 13:00:00", "2014-04-26 12:58:15", '1 minute, 45 secondes il y a'),
+            array("2014-04-26 13:00:00", "2014-04-26 11:20:00", '1 heure, 40 minutes il y a'),
             array("2014-04-26 13:00:00", "2014-04-27 13:15:00", '1 jour, 15 minutes maintenant'),
             array("2014-04-26 13:00:00", "2014-05-03 15:00:00", '7 jours, 2 heures maintenant'),
             array("2014-04-26 13:00:00", "2015-04-28 17:00:00", '1 année, 2 jours, 4 heures maintenant'),
             array("2014-04-26 13:00:00", "2014-04-28 23:00:00", '2 jours, 10 heures maintenant'),
-            array("2014-04-26 13:00:00", "2014-04-25 11:20:00", '1 jour, 1 heure, 40 minutes il y\'a'),
+            array("2014-04-26 13:00:00", "2014-04-25 11:20:00", '1 jour, 1 heure, 40 minutes il y a'),
             array("2014-04-26 13:00:00", "2016-04-27 13:00:00", '2 années, 1 jour maintenant'),
         );
 

--- a/src/Coduo/PHPHumanizer/Resources/translations/difference.fr.yml
+++ b/src/Coduo/PHPHumanizer/Resources/translations/difference.fr.yml
@@ -2,26 +2,26 @@ just_now:
   past: "[0,Inf] à l'instant"
   future: "[0,Inf] à l'instant"
 second:
-  past: "{1} il y'a %count% seconde|[2,Inf] il y'a %count% secondes"
-  future: "{1} il y'a maintenant %count% seconde|[2,Inf] il y'a maintenant %count% secondes"
+  past: "{1} il y a %count% seconde|[2,Inf] il y a %count% secondes"
+  future: "{1} il y a maintenant %count% seconde|[2,Inf] il y a maintenant %count% secondes"
 minute:
-  past: "{1} il y'a %count% minute|[2,Inf] il y'a %count% minutes"
-  future: "{1} il y'a maintenant %count% minute|[2,Inf] il y'a maintenant %count% minutes"
+  past: "{1} il y a %count% minute|[2,Inf] il y'a %count% minutes"
+  future: "{1} il y a maintenant %count% minute|[2,Inf] il y a maintenant %count% minutes"
 hour:
-  past: "{1} il y'a %count% heure|[2,Inf] il y'a %count% heure"
-  future: "{1} il y'a maintenant %count% heure|[2,Inf] il y'a maintenant %count% heures"
+  past: "{1} il y a %count% heure|[2,Inf] il y a %count% heure"
+  future: "{1} il y a maintenant %count% heure|[2,Inf] il y a maintenant %count% heures"
 day:
-  past: "{1} il y'a %count% jour|[2,Inf] il y'a %count% jours"
-  future: "{1} il y'a maintenant %count% jour|[2,Inf] il y'a maintenant %count% jours"
+  past: "{1} il y a %count% jour|[2,Inf] il y a %count% jours"
+  future: "{1} il y a maintenant %count% jour|[2,Inf] il y a maintenant %count% jours"
 week:
-  past: "{1} il y'a %count% semaine|[2,Inf] il y'a %count% semaines"
-  future: "{1} il y'a maintenant %count% semaine|[2,Inf] il y'a maintenant %count% semaines"
+  past: "{1} il y a %count% semaine|[2,Inf] il y a %count% semaines"
+  future: "{1} il y a maintenant %count% semaine|[2,Inf] il y a maintenant %count% semaines"
 month:
-  past: "{1} il y'a %count% mois|[2,Inf] il y'a %count% mois"
+  past: "{1} il y a %count% mois|[2,Inf] il y a %count% mois"
   future: "{1} %count% mois maintenant|[2,Inf] %count% mois maintenant"
 year:
-  past: "{1} il y'a %count% année|[2,Inf] il y'a %count% années"
-  future: "{1} il y'a maintenant %count% année|[2,Inf] il y'a maintenant %count% années"
+  past: "{1} il y a %count% année|[2,Inf] il y a %count% années"
+  future: "{1} il y a maintenant %count% année|[2,Inf] il y a maintenant %count% années"
 
 compound:
   second: "{1} %count% seconde|[2,Inf] %count% secondes"
@@ -31,5 +31,5 @@ compound:
   week: "{1} %count% semaine|[2,Inf] %count% semaines"
   month: "{1} %count% mois|[2,Inf] %count% mois"
   year: "{1} %count% année|[2,Inf] %count% années"
-  ago: "il y'a"
+  ago: "il y a"
   from_now: "maintenant"


### PR DESCRIPTION
The right expression is "il y a", not "il y'a"