### PR TITLE
Add basic Russian support

### DIFF
--- a/spec/Coduo/PHPHumanizer/DateTimeSpec.php
+++ b/spec/Coduo/PHPHumanizer/DateTimeSpec.php
@@ -237,4 +237,22 @@ class DateTimeSpec extends ObjectBehavior
             $this->preciseDifference(new \DateTime($example[0]), new \DateTime($example[1]), 'it')->shouldReturn($example[2]);
         }
     }
+
+    function it_humanizes_precise_difference_between_dates_for_ru_locale()
+    {
+        $examples = array(
+            array("2015-02-01 12:00:00", "2015-02-01 10:57:55", '1 час, 2 минуты, 5 секунд назад'),
+            array("2015-02-01 12:00:00", "2015-02-01 09:54:59", '2 часа, 5 минут, 1 секунда назад'),
+            array("2015-02-01 12:00:00", "2015-02-01 06:58:58", '5 часов, 1 минута, 2 секунды назад'),
+            array("2015-02-01 12:00:00", "2015-02-01 14:01:05", 'через 2 часа, 1 минуту, 5 секунд'),
+            array("2015-02-01 12:00:00", "2014-01-30 07:00:00", '1 год, 2 дня, 5 часов назад'),
+            array("2015-02-01 12:00:00", "2013-01-27 11:00:00", '2 года, 5 дней, 1 час назад'),
+            array("2015-02-01 12:00:00", "2010-01-31 10:00:00", '5 лет, 1 день, 2 часа назад'),
+            array("2015-02-01 12:00:00", "2017-02-06 13:00:00", 'через 2 года, 5 дней, 1 час'),
+        );
+
+        foreach ($examples as $example) {
+            $this->preciseDifference(new \DateTime($example[0]), new \DateTime($example[1]), 'ru')->shouldReturn($example[2]);
+        }
+    }
 }

--- a/src/Coduo/PHPHumanizer/Resources/translations/difference.ru.yml
+++ b/src/Coduo/PHPHumanizer/Resources/translations/difference.ru.yml
@@ -1,0 +1,35 @@
+just_now:
+  past: "только что"
+  future: "только что"
+second:
+  past: "%count% секунда назад|%count% секунды назад|%count% секунд назад"
+  future: "через %count% секунду|через %count% секунды|через %count% секунд"
+minute:
+  past: "%count% минута назад|%count% минуты назад|%count% минут назад"
+  future: "через %count% минуту|через %count% минуты|через %count% минут"
+hour:
+  past: "%count% час назад|%count% часа назад|%count% часов назад"
+  future: "через %count% час|через %count% часа"
+day:
+  past: "%count% день назад|%count% дня назад|%count% дней назад"
+  future: "через %count% день|через %count% дня|через %count% дней"
+week:
+  past: "%count% неделя назад|%count% недели назад|%count% недель назад"
+  future: "через %count% неделю|через %count% недели|через %count% недель"
+month:
+  past: "%count% месяц назад|%count% месяца назад|%count% месяцев назад"
+  future: "через %count% месяц|через %count% месяца|через %count% месяцев"
+year:
+  past: "%count% год назад|%count% года назад|%count% лет назад"
+  future: "через %count% год|через %count% года|через %count% лет"
+
+compound:
+  second: "%count% секунда|%count% секунды|%count% секунд"
+  minute: "%count% минута|%count% минуты|%count% минут"
+  hour: "%count% час|%count% часа|%count% часов"
+  day: "%count% день|%count% дня|%count% дней"
+  week: "%count% неделя|%count% недели|%count недель"
+  month: "%count% месяц|%count% месяца|%count% месяцев"
+  year: "%count% год|%count% года|%count% лет"
+  ago: "назад"
+  from_now: "через"


### PR DESCRIPTION
This commit adds basic Russian support to DateTimeDifference.

However, fixes are required. The compound items are supposed to be different for "past" and "future" dates. For now they're translated as "past". Also, the "future" prefix (`from_now`) goes before the text:

```php
second:
  past: "%count% секунда назад|%count% секунды назад|%count% секунд назад"
  future: "через %count% секунду|через %count% секунды|через %count% секунд"
```

The translation format is taken from [Symfony/Component/Translation/PluralizationRules.php](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Translation/PluralizationRules.php) and has to be tested.