### PR TITLE
Add Spanish translation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Currently we support following languages:
 * [Bulgarian] (src/Coduo/PHPHumanizer/Resources/translations/difference.bg.yml)
 * [Indonesian] (src/Coduo/PHPHumanizer/Resources/translations/difference.id.yml)
 * [Chinese Simplified] (src/Coduo/PHPHumanizer/Resources/translations/difference.zh_CN.yml)
+* [Spanish] (src/Coduo/PHPHumanizer/Resources/translations/difference.es.yml)
 
 # Credits
 

--- a/src/Coduo/PHPHumanizer/Resources/translations/difference.es.yml
+++ b/src/Coduo/PHPHumanizer/Resources/translations/difference.es.yml
@@ -1,0 +1,35 @@
+just_now:
+  past: "[0,Inf] ahora mismo"
+  future: "[0,Inf] ahora mismo"
+second:
+  past: "{1} Hace %count% segundo |[2,Inf] Hace %count% segundos"
+  future: "{1} Dentro de %count% segundo|[2,Inf] Dentro de %count% segundos"
+minute:
+  past: "{1} Hace %count% minuto|[2,Inf] Hace %count% minutos"
+  future: "{1} Dentro de %count% minuto|[2,Inf] Dentro de %count% minutos"
+hour:
+  past: "{1} Hace %count% hora|[2,Inf] Hace %count% horas"
+  future: "{1} Dentro de %count% hora|[2,Inf] Dentro de %count% horas"
+day:
+  past: "{1} Hace %count% día|[2,Inf] Hace %count% días"
+  future: "{1} Dentro de %count% día|[2,Inf] Dentro de %count% días"
+week:
+  past: "{1} Hace %count% semana|[2,Inf] Hace %count% semanas"
+  future: "{1} Dentro de %count% semana|[2,Inf] Dentro de %count% semanas"
+month:
+  past: "{1} Hace %count% mes|[2,Inf] Hace %count% meses"
+  future: "{1} Dentro de %count% mes|[2,Inf] Dentro de %count% meses"
+year:
+  past: "{1} Hace %count% año|[2,Inf] Hace %count% años"
+  future: "{1} Dentro de %count% año|[2,Inf] Dentro de %count% años"
+
+compound:
+  second: "{1} %count% segundo|[2,Inf] %count% segundos"
+  minute: "{1} %count% minuto|[2,Inf] %count% minutos"
+  hour: "{1} %count% hora|[2,Inf] %count% horas"
+  day: "{1} %count% día|[2,Inf] %count% días"
+  week: "{1} %count% semana|[2,Inf] %count% semanas"
+  month: "{1} %count% mes|[2,Inf] %count% meses"
+  year: "{1} %count% año|[2,Inf] %count% años"
+  ago: "atrás"
+  from_now: "a partir de ahora"

--- a/src/Coduo/PHPHumanizer/Resources/translations/difference.es.yml
+++ b/src/Coduo/PHPHumanizer/Resources/translations/difference.es.yml
@@ -2,26 +2,26 @@ just_now:
   past: "[0,Inf] ahora mismo"
   future: "[0,Inf] ahora mismo"
 second:
-  past: "{1} Hace %count% segundo |[2,Inf] Hace %count% segundos"
-  future: "{1} Dentro de %count% segundo|[2,Inf] Dentro de %count% segundos"
+  past: "{1} hace %count% segundo |[2,Inf] hace %count% segundos"
+  future: "{1} dentro de %count% segundo|[2,Inf] dentro de %count% segundos"
 minute:
-  past: "{1} Hace %count% minuto|[2,Inf] Hace %count% minutos"
-  future: "{1} Dentro de %count% minuto|[2,Inf] Dentro de %count% minutos"
+  past: "{1} hace %count% minuto|[2,Inf] hace %count% minutos"
+  future: "{1} dentro de %count% minuto|[2,Inf] dentro de %count% minutos"
 hour:
-  past: "{1} Hace %count% hora|[2,Inf] Hace %count% horas"
-  future: "{1} Dentro de %count% hora|[2,Inf] Dentro de %count% horas"
+  past: "{1} hace %count% hora|[2,Inf] hace %count% horas"
+  future: "{1} dentro de %count% hora|[2,Inf] dentro de %count% horas"
 day:
-  past: "{1} Hace %count% día|[2,Inf] Hace %count% días"
-  future: "{1} Dentro de %count% día|[2,Inf] Dentro de %count% días"
+  past: "{1} hace %count% día|[2,Inf] hace %count% días"
+  future: "{1} dentro de %count% día|[2,Inf] dentro de %count% días"
 week:
-  past: "{1} Hace %count% semana|[2,Inf] Hace %count% semanas"
-  future: "{1} Dentro de %count% semana|[2,Inf] Dentro de %count% semanas"
+  past: "{1} hace %count% semana|[2,Inf] hace %count% semanas"
+  future: "{1} dentro de %count% semana|[2,Inf] dentro de %count% semanas"
 month:
-  past: "{1} Hace %count% mes|[2,Inf] Hace %count% meses"
-  future: "{1} Dentro de %count% mes|[2,Inf] Dentro de %count% meses"
+  past: "{1} hace %count% mes|[2,Inf] hace %count% meses"
+  future: "{1} dentro de %count% mes|[2,Inf] dentro de %count% meses"
 year:
-  past: "{1} Hace %count% año|[2,Inf] Hace %count% años"
-  future: "{1} Dentro de %count% año|[2,Inf] Dentro de %count% años"
+  past: "{1} hace %count% año|[2,Inf] hace %count% años"
+  future: "{1} dentro de %count% año|[2,Inf] dentro de %count% años"
 
 compound:
   second: "{1} %count% segundo|[2,Inf] %count% segundos"

--- a/src/Coduo/PHPHumanizer/Resources/translations/difference.es.yml
+++ b/src/Coduo/PHPHumanizer/Resources/translations/difference.es.yml
@@ -31,5 +31,5 @@ compound:
   week: "{1} %count% semana|[2,Inf] %count% semanas"
   month: "{1} %count% mes|[2,Inf] %count% meses"
   year: "{1} %count% año|[2,Inf] %count% años"
-  ago: "atrás"
-  from_now: "a partir de ahora"
+  past: "hace %value%"
+  future: "dentro de %value%"

--- a/src/Coduo/PHPHumanizer/Resources/translations/oxford.es.yml
+++ b/src/Coduo/PHPHumanizer/Resources/translations/oxford.es.yml
@@ -1,0 +1,3 @@
+only_two: "%first% y %second%"
+comma_separated: "%list%, y %last%"
+comma_separated_with_limit: "{1} %list%, y 1 más|[2,Inf] %list%, y %count% más"

--- a/tests/Coduo/PHPHumanizer/Tests/DateTimeTest.php
+++ b/tests/Coduo/PHPHumanizer/Tests/DateTimeTest.php
@@ -155,6 +155,25 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
             array("2014-05-01", "2014-04-01", '1 bulan yang lalu', 'id'),
             array("2015-05-01", "2014-04-01", '1 tahun yang lalu', 'id'),
             array("2014-05-01", "2016-04-01", '2 tahun dari sekarang', 'id'),
+            
+            // Spanish
+            array("2014-04-26 13:00:00", "2014-04-26 13:00:00", 'ahora mismo', 'es'),
+            array("2014-04-26 13:00:00", "2014-04-26 13:00:05", 'dentro de 5 segundos', 'es'),
+            array("2014-04-26 13:00:00", "2014-04-26 12:59:00", 'hace 1 minuto', 'es'),
+            array("2014-04-26 13:00:00", "2014-04-26 12:45:00", 'hace 15 minutos', 'es'),
+            array("2014-04-26 13:00:00", "2014-04-26 13:15:00", 'dentro de 15 minutos', 'es'),
+            array("2014-04-26 13:00:00", "2014-04-26 14:00:00", 'dentro de 1 hora', 'es'),
+            array("2014-04-26 13:00:00", "2014-04-26 15:00:00", 'dentro de 2 horas', 'es'),
+            array("2014-04-26 13:00:00", "2014-04-26 12:00:00", 'hace 1 hora', 'es'),
+            array("2014-04-26", "2014-04-25", 'hace 1 día', 'es'),
+            array("2014-04-26", "2014-04-24", 'hace 2 días', 'es'),
+            array("2014-04-26", "2014-04-28", 'dentro de 2 días', 'es'),
+            array("2014-04-01", "2014-04-15", 'dentro de 2 semanas', 'es'),
+            array("2014-04-15", "2014-04-07", 'hace 1 semana', 'es'),
+            array("2014-01-01", "2014-04-01", 'dentro de 3 meses', 'es'),
+            array("2014-05-01", "2014-04-01", 'hace 1 mes', 'es'),
+            array("2015-05-01", "2014-04-01", 'hace 1 año', 'es'),
+            array("2014-05-01", "2016-04-01", 'dentro de 2 años', 'es'),
         );
     }
 
@@ -293,6 +312,16 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
             array("2014-04-26 13:00:00", "2014-04-28 23:00:00", '2 hari, 10 jam dari sekarang', 'id'),
             array("2014-04-26 13:00:00", "2014-04-25 11:20:00", '1 hari, 1 jam, 40 menit yang lalu', 'id'),
             array("2014-04-26 13:00:00", "2016-04-27 13:00:00", '2 tahun, 1 hari dari sekarang', 'id'),
+
+            // Spanish
+            array("2014-04-26 13:00:00", "2014-04-26 12:58:15", 'hace 1 minuto, 45 segundos', 'es'),
+            array("2014-04-26 13:00:00", "2014-04-26 11:20:00", 'hace 1 hora, 40 minutos', 'es'),
+            array("2014-04-26 13:00:00", "2014-04-27 13:15:00", 'dentro de 1 día, 15 minutos', 'es'),
+            array("2014-04-26 13:00:00", "2014-05-03 15:00:00", 'dentro de 7 días, 2 horas', 'es'),
+            array("2014-04-26 13:00:00", "2015-04-28 17:00:00", 'dentro de 1 año, 2 días, 4 horas', 'es'),
+            array("2014-04-26 13:00:00", "2014-04-28 23:00:00", 'dentro de 2 días, 10 horas', 'es'),
+            array("2014-04-26 13:00:00", "2014-04-25 11:20:00", 'hace 1 día, 1 hora, 40 minutos', 'es'),
+            array("2014-04-26 13:00:00", "2016-04-27 13:00:00", 'dentro de 2 años, 1 día', 'es'),
         );
     }
 }


### PR DESCRIPTION
Initial work on a Spanish translation. There might be a problem with the way you generate the compound  past/future in PreciseFormatter, which is always a suffix. In Spanish, we actually use a prefix. When I figure out a way of implementing it I'll send in another pull request.