### PR TITLE
Addition of Portuguese (pt) language translation (with spec tests)

### DIFF
--- a/spec/Coduo/PHPHumanizer/DateTimeSpec.php
+++ b/spec/Coduo/PHPHumanizer/DateTimeSpec.php
@@ -94,6 +94,33 @@ class DateTimeSpec extends ObjectBehavior
         }
     }
 
+    function it_humanize_difference_between_dates_for_pt_locale()
+    {
+        $examples = array(
+            array("2014-04-26 13:00:00", "2014-04-26 13:00:00", 'agora'),
+            array("2014-04-26 13:00:00", "2014-04-26 13:00:05", '5 segundos a partir de agora'),
+            array("2014-04-26 13:00:00", "2014-04-26 12:59:00", '1 minuto atrás'),
+            array("2014-04-26 13:00:00", "2014-04-26 12:45:00", '15 minutos atrás'),
+            array("2014-04-26 13:00:00", "2014-04-26 13:15:00", '15 minutos a partir de agora'),
+            array("2014-04-26 13:00:00", "2014-04-26 14:00:00", '1 hora a partir de agora'),
+            array("2014-04-26 13:00:00", "2014-04-26 15:00:00", '2 horas a partir de agora'),
+            array("2014-04-26 13:00:00", "2014-04-26 12:00:00", '1 hora atrás'),
+            array("2014-04-26", "2014-04-25", '1 dia atrás'),
+            array("2014-04-26", "2014-04-24", '2 dias atrás'),
+            array("2014-04-26", "2014-04-28", '2 dias a partir de agora'),
+            array("2014-04-01", "2014-04-15", '2 semanas a partir de agora'),
+            array("2014-04-15", "2014-04-07", '1 semana atrás'),
+            array("2014-01-01", "2014-04-01", '3 meses a partir de agora'),
+            array("2014-05-01", "2014-04-01", '1 mês atrás'),
+            array("2015-05-01", "2014-04-01", '1 ano atrás'),
+            array("2014-05-01", "2016-04-01", '2 anos a partir de agora'),
+        );
+
+        foreach ($examples as $example) {
+            $this->difference(new \DateTime($example[0]), new \DateTime($example[1]), 'pt')->shouldReturn($example[2]);
+        }
+    }
+
     function it_humanizes_precise_difference_between_dates()
     {
         $examples = array(
@@ -199,6 +226,24 @@ class DateTimeSpec extends ObjectBehavior
 
         foreach ($examples as $example) {
             $this->preciseDifference(new \DateTime($example[0]), new \DateTime($example[1]), 'fr')->shouldReturn($example[2]);
+        }
+    }
+
+    function it_humanizes_precise_difference_between_dates_for_pt_locale()
+    {
+        $examples = array(
+            array("2014-04-26 13:00:00", "2014-04-26 12:58:15", '1 minuto, 45 segundos atrás'),
+            array("2014-04-26 13:00:00", "2014-04-26 11:20:00", '1 hora, 40 minutos atrás'),
+            array("2014-04-26 13:00:00", "2014-04-27 13:15:00", '1 dia, 15 minutos a partir de agora'),
+            array("2014-04-26 13:00:00", "2014-05-03 15:00:00", '7 dias, 2 horas a partir de agora'),
+            array("2014-04-26 13:00:00", "2015-04-28 17:00:00", '1 ano, 2 dias, 4 horas a partir de agora'),
+            array("2014-04-26 13:00:00", "2014-04-28 23:00:00", '2 dias, 10 horas a partir de agora'),
+            array("2014-04-26 13:00:00", "2014-04-25 11:20:00", '1 dia, 1 hora, 40 minutos atrás'),
+            array("2014-04-26 13:00:00", "2016-04-27 13:00:00", '2 anos, 1 dia a partir de agora'),
+        );
+
+        foreach ($examples as $example) {
+            $this->preciseDifference(new \DateTime($example[0]), new \DateTime($example[1]), 'pt_BR')->shouldReturn($example[2]);
         }
     }
 

--- a/src/Coduo/PHPHumanizer/Resources/translations/difference.pt.yml
+++ b/src/Coduo/PHPHumanizer/Resources/translations/difference.pt.yml
@@ -1,0 +1,35 @@
+just_now:
+  past: "[0,Inf] agora"
+  future: "[0,Inf] agora"
+second:
+  past: "{1} %count% segundo atrás|[2,Inf] %count% segundos atrás"
+  future: "{1} %count% segundo a partir de agora|[2,Inf] %count% segundos a partir de agora"
+minute:
+  past: "{1} %count% minuto atrás|[2,Inf] %count% minutos atrás"
+  future: "{1} %count% minuto a partir de agora|[2,Inf] %count% minutos a partir de agora"
+hour:
+  past: "{1} %count% hora atrás|[2,Inf] %count% horas atrás"
+  future: "{1} %count% hora a partir de agora|[2,Inf] %count% horas a partir de agora"
+day:
+  past: "{1} %count% dia atrás|[2,Inf] %count% dias atrás"
+  future: "{1} %count% dia a partir de agora|[2,Inf] %count% dias a partir de agora"
+week:
+  past: "{1} %count% semana atrás|[2,Inf] %count% semanas atrás"
+  future: "{1} %count% semana a partir de agora|[2,Inf] %count% semanas a partir de agora"
+month:
+  past: "{1} %count% mês atrás|[2,Inf] %count% meses atrás"
+  future: "{1} %count% mês a partir de agora|[2,Inf] %count% meses a partir de agora"
+year:
+  past: "{1} %count% ano atrás|[2,Inf] %count% anos atrás"
+  future: "{1} %count% ano a partir de agora|[2,Inf] %count% anos a partir de agora"
+
+compound:
+  second: "{1} %count% segundo|[2,Inf] %count% segundos"
+  minute: "{1} %count% minuto|[2,Inf] %count% minutos"
+  hour: "{1} %count% hora|[2,Inf] %count% horas"
+  day: "{1} %count% dia|[2,Inf] %count% dias"
+  week: "{1} %count% semana|[2,Inf] %count% semana"
+  month: "{1} %count% mês|[2,Inf] %count% meses"
+  year: "{1} %count% ano|[2,Inf] %count% anos"
+  ago: "atrás"
+  from_now: "a partir de agora"


### PR DESCRIPTION
Hi,

In terms of context of the translations when you have the text:

> %count% seconds from now

you mean the same as:

> in about %count% seconds  

or

> in %count% seconds  

Because the translation of the second sentence makes more sense to me in Portuguese and if it's the same for you I will change the texts.

PS: I'm also getting some errors in the tests for Numbers in my machine but I will look into that later.