### PR TITLE
Truncate check length of append

### DIFF
--- a/spec/Coduo/PHPHumanizer/StringSpec.php
+++ b/spec/Coduo/PHPHumanizer/StringSpec.php
@@ -32,5 +32,11 @@ class StringSpec extends ObjectBehavior
         $this->truncate($text, 0)->shouldReturn("Lorem");
         $this->truncate($text, 0, '...')->shouldReturn("Lorem...");
         $this->truncate($text, -2)->shouldReturn($text);
+
+        $textShort = 'Short text';
+        $this->truncate($textShort, 4, '...')->shouldReturn("Short...");
+        $this->truncate($textShort, 5, '...')->shouldReturn("Short...");
+        $this->truncate($textShort, 6, '...')->shouldReturn("Short...");
+        $this->truncate($textShort, 7, '...')->shouldReturn("Short text");
     }
 }

--- a/spec/Coduo/PHPHumanizer/StringSpec.php
+++ b/spec/Coduo/PHPHumanizer/StringSpec.php
@@ -34,9 +34,15 @@ class StringSpec extends ObjectBehavior
         $this->truncate($text, -2)->shouldReturn($text);
 
         $textShort = 'Short text';
+        $this->truncate($textShort, 1, '...')->shouldReturn("Short...");
+        $this->truncate($textShort, 2, '...')->shouldReturn("Short...");
+        $this->truncate($textShort, 3, '...')->shouldReturn("Short...");
         $this->truncate($textShort, 4, '...')->shouldReturn("Short...");
         $this->truncate($textShort, 5, '...')->shouldReturn("Short...");
         $this->truncate($textShort, 6, '...')->shouldReturn("Short...");
         $this->truncate($textShort, 7, '...')->shouldReturn("Short text");
+        $this->truncate($textShort, 8, '...')->shouldReturn("Short text");
+        $this->truncate($textShort, 9, '...')->shouldReturn("Short text");
+        $this->truncate($textShort, 10, '...')->shouldReturn("Short text");
     }
 }

--- a/src/Coduo/PHPHumanizer/String/Truncate.php
+++ b/src/Coduo/PHPHumanizer/String/Truncate.php
@@ -33,7 +33,7 @@ class Truncate
 
     public function __toString()
     {
-        if ($this->charactersCount < 0 || strlen($this->text) <= $this->charactersCount) {
+        if ($this->charactersCount < 0 || strlen($this->text) <= ($this->charactersCount + mb_strlen($this->append))) {
             return $this->text;
         }
 


### PR DESCRIPTION
There is a bug when the size to troncate + the size of the append is the same as the string length.

This cause even a more bigger issue because it doesn't check for a breakpoint since there are no more space in the string thus abruptly cuting the string.

```php
$textShort = 'Short text';
$this->truncate($textShort, 7, '...'); // Expecting: "Short text" (len: 10) return "Short t..."
```