### PR TITLE
added phpunit tests and found a bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,4 @@ install:
 
 script:
   - ./bin/phpspec run --format=pretty
+  - ./bin/phpunit -vvv tests/

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "autoload": {
         "psr-4": {
             "": "src",
-            "Coduo\\PHPHumanizer\\Tests": "tests/"
+            "Coduo\\PHPHumanizer\\Tests\\": "tests/"
         }
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,17 @@
         "symfony/yaml": "~2.3"
     },
     "require-dev": {
-        "phpspec/phpspec": "2.0.*"
+        "phpspec/phpspec": "2.0.*",
+        "phpunit/phpunit": "^4.5|^5.0"
     },
     "config": {
         "bin-dir": "bin"
     },
     "autoload": {
-        "psr-4": {"": "src"}
+        "psr-4": {
+            "": "src",
+            "Coduo\\PHPHumanizer\\Tests": "tests/"
+        }
     },
     "extra": {
         "branch-alias": {

--- a/src/Coduo/PHPHumanizer/Number.php
+++ b/src/Coduo/PHPHumanizer/Number.php
@@ -40,7 +40,7 @@ class Number
         return $romanNumeral->toRoman($number);
     }
 
-    public function fromRoman($number)
+    public static function fromRoman($number)
     {
         $romanNumeral = new RomanNumeral();
 

--- a/tests/unit/DateTime/DifferenceTest.php
+++ b/tests/unit/DateTime/DifferenceTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Coduo\PHPHumanizer\Tests\DateTime;
+
+use Coduo\PHPHumanizer\DateTime\Difference;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * Class DifferenceTest
+ *
+ * @package Coduo\PHPHumanizer\Tests\DateTime
+ */
+class DifferenceTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider differenceDataProvider
+     *
+     * @param $expected
+     * @param $firstDate
+     * @param $secondDate
+     * @param $instance
+     * @param $isPast
+     */
+    public function test_calculating_differences_between_dates($expected, $firstDate, $secondDate, $instance, $isPast )
+    {
+        $diff = new Difference($firstDate, $secondDate);
+
+        $this->assertTrue(is_a($diff->getUnit(), $instance));
+        $this->assertEquals($expected, $diff->getQuantity());
+        $this->assertEquals($isPast, $diff->isPast());
+    }
+
+    /**
+     * @return array
+     */
+    public function differenceDataProvider()
+    {
+        return array(
+            array(15, new \DateTime("2014-04-26 13:00:00"), new \DateTime("2014-04-26 12:45:00"), 'Coduo\PHPHumanizer\DateTime\Unit\Minute', true),
+            array(15, new \DateTime("2014-04-26 13:00:00"), new \DateTime("2014-04-26 13:15:00"), 'Coduo\PHPHumanizer\DateTime\Unit\Minute', false),
+            array(2, new \DateTime("2014-04-26 13:00:00"), new \DateTime("2014-04-26 11:00:00"), 'Coduo\PHPHumanizer\DateTime\Unit\Hour', true),
+            array(3, new \DateTime("2014-04-26 13:00:00"), new \DateTime("2014-04-26 16:00:00"), 'Coduo\PHPHumanizer\DateTime\Unit\Hour', false),
+            array(1, new \DateTime("2014-04-10"), new \DateTime("2014-04-09"), 'Coduo\PHPHumanizer\DateTime\Unit\Day', true),
+            array(1, new \DateTime("2014-04-10"), new \DateTime("2014-04-11"), 'Coduo\PHPHumanizer\DateTime\Unit\Day', false),
+            array(2, new \DateTime("2014-04-15"), new \DateTime("2014-04-01"), 'Coduo\PHPHumanizer\DateTime\Unit\Week', true),
+            array(2, new \DateTime("2014-04-01"), new \DateTime("2014-04-15"), 'Coduo\PHPHumanizer\DateTime\Unit\Week',	false),
+            array(1, new \DateTime("2014-04-01"), new \DateTime("2014-03-01"), 'Coduo\PHPHumanizer\DateTime\Unit\Month', true),
+            array(1, new \DateTime("2014-04-01"), new \DateTime("2014-05-01"), 'Coduo\PHPHumanizer\DateTime\Unit\Month', false),
+            array(2, new \DateTime("2014-01-01"), new \DateTime("2012-01-01"), 'Coduo\PHPHumanizer\DateTime\Unit\Year', true),
+            array(1, new \DateTime("2014-01-01"), new \DateTime("2015-01-01"), 'Coduo\PHPHumanizer\DateTime\Unit\Year', false),
+        );
+    }
+}
+

--- a/tests/unit/DateTime/FormatterTest.php
+++ b/tests/unit/DateTime/FormatterTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Coduo\PHPHumanizer\Tests\DateTime;
+
+use Coduo\PHPHumanizer\DateTime\Formatter;
+use Coduo\PHPHumanizer\DateTime\Unit\Minute;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * Class FormatterTest
+ *
+ * @package Coduo\PHPHumanizer\Tests\DateTime
+ */
+class FormatterTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider formatterDataProvider
+     *
+     * @param        $unit
+     * @param        $quantity
+     * @param        $isPast
+     * @param        $formatted
+     * @param string $locale
+     */
+    public function test_formatting_datetimes($unit, $quantity, $isPast, $formatted, $locale = 'en')
+    {
+        $translator = $this->prophesize('Symfony\Component\Translation\Translator');
+
+        $translator->transChoice(
+            'minute.past',
+            10,
+            array('%count%' => 10),
+            'difference',
+            'en'
+        )->willReturn('10 minutes ago');
+
+        $translator->transChoice(
+            'minute.past',
+            10,
+            array('%count%' => 10),
+            'difference',
+            'pl'
+        )->willReturn('10 minut temu');
+
+        $diff = $this->prophesize('\Coduo\PHPHumanizer\DateTime\Difference');
+
+        $diff->getUnit()->willReturn($unit);
+        $diff->getQuantity()->willReturn($quantity);
+        $diff->isPast()->willReturn($isPast);
+
+        $formatter = new Formatter($translator->reveal());
+
+        $this->assertEquals($formatted, $formatter->formatDifference($diff->reveal(), $locale));
+    }
+
+    /**
+     * @return array
+     */
+    public function formatterDataProvider()
+    {
+        return array(
+            array(new Minute(), 10, true, '10 minutes ago'),
+            array(new Minute(), 10, true, '10 minut temu', 'pl'),
+        );
+    }
+}

--- a/tests/unit/DateTimeTest.php
+++ b/tests/unit/DateTimeTest.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Coduo\PHPHumanizer\Tests;
+
+use Coduo\PHPHumanizer\DateTime;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * Class DateTimeTest
+ *
+ * @package Coduo\PHPHumanizer\Tests
+ */
+class DateTimeTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     * @dataProvider humanizeDataProvider
+     *
+     * @param        $firstDate
+     * @param        $secondDate
+     * @param        $expected
+     * @param string $locale
+     */
+    public function test_humanize_difference_between_dates($firstDate, $secondDate, $expected, $locale = 'en')
+    {
+        $datetime = new DateTime();
+
+        $this->assertEquals($expected, $datetime->difference(new \DateTime($firstDate), new \DateTime($secondDate), $locale));
+        $this->assertEquals($expected, DateTime::difference(new \DateTime($firstDate), new \DateTime($secondDate), $locale));
+    }
+
+    /**
+     * @dataProvider preciseDifferenceDataProvider
+     *
+     * @param        $firstDate
+     * @param        $secondDate
+     * @param        $expected
+     * @param string $locale
+     */
+    public function test_humanize_precise_difference_between_dates($firstDate, $secondDate, $expected, $locale = 'en')
+    {
+        $datetime = new DateTime();
+
+        $this->assertEquals($expected, $datetime->preciseDifference(new \DateTime($firstDate), new \DateTime($secondDate), $locale));
+        $this->assertEquals($expected, DateTime::preciseDifference(new \DateTime($firstDate), new \DateTime($secondDate), $locale));
+    }
+
+    /**
+     * @return array
+     */
+    public function humanizeDataProvider()
+    {
+        return array(
+            array("2014-04-26 13:00:00", "2014-04-26 13:00:00", 'just now'),
+            array("2014-04-26 13:00:00", "2014-04-26 13:00:05", '5 seconds from now'),
+            array("2014-04-26 13:00:00", "2014-04-26 12:59:00", '1 minute ago'),
+            array("2014-04-26 13:00:00", "2014-04-26 12:45:00", '15 minutes ago'),
+            array("2014-04-26 13:00:00", "2014-04-26 13:15:00", '15 minutes from now'),
+            array("2014-04-26 13:00:00", "2014-04-26 14:00:00", '1 hour from now'),
+            array("2014-04-26 13:00:00", "2014-04-26 15:00:00", '2 hours from now'),
+            array("2014-04-26 13:00:00", "2014-04-26 12:00:00", '1 hour ago'),
+            array("2014-04-26", "2014-04-25", '1 day ago'),
+            array("2014-04-26", "2014-04-24", '2 days ago'),
+            array("2014-04-26", "2014-04-28", '2 days from now'),
+            array("2014-04-01", "2014-04-15", '2 weeks from now'),
+            array("2014-04-15", "2014-04-07", '1 week ago'),
+            array("2014-01-01", "2014-04-01", '3 months from now'),
+            array("2014-05-01", "2014-04-01", '1 month ago'),
+            array("2015-05-01", "2014-04-01", '1 year ago'),
+            array("2014-05-01", "2016-04-01", '2 years from now'),
+
+            array("2014-04-26 13:00:00", "2014-04-26 13:00:00", 'w tym momencie', 'pl'),
+            array("2014-04-26 13:00:00", "2014-04-26 13:00:05", 'za 5 sekund', 'pl'),
+            array("2014-04-26 13:00:00", "2014-04-26 12:59:00", 'minutę temu', 'pl'),
+            array("2014-04-26 13:00:00", "2014-04-26 12:45:00", '15 minut temu', 'pl'),
+            array("2014-04-26 13:00:00", "2014-04-26 13:15:00", 'za 15 minut', 'pl'),
+            array("2014-04-26 13:00:00", "2014-04-26 14:00:00", 'za godzinę', 'pl'),
+            array("2014-04-26 13:00:00", "2014-04-26 15:00:00", 'za 2 godziny', 'pl'),
+            array("2014-04-26 13:00:00", "2014-04-26 12:00:00", 'godzinę temu', 'pl'),
+            array("2014-04-26 13:00:00", "2014-04-26 15:00:00", 'za 2 godziny', 'pl'),
+            array("2014-04-26 13:00:00", "2014-04-26 12:00:00", 'godzinę temu', 'pl'),
+            array("2014-04-26", "2014-04-25", 'wczoraj', 'pl'),
+            array("2014-04-26", "2014-04-24", '2 dni temu', 'pl'),
+            array("2014-04-26", "2014-04-28", 'za 2 dni', 'pl'),
+            array("2014-04-01", "2014-04-15", 'za 2 tygodnie', 'pl'),
+            array("2014-04-15", "2014-04-07", 'tydzień temu', 'pl'),
+            array("2014-01-01", "2014-04-01", 'za 3 miesiące', 'pl'),
+            array("2014-05-01", "2014-04-01", 'miesiąc temu', 'pl'),
+            array("2015-05-01", "2014-04-01", 'rok temu', 'pl'),
+            array("2014-05-01", "2016-04-01", 'za 2 lata', 'pl'),
+            array("2014-05-01", "2009-04-01", '5 lat temu', 'pl'),
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function preciseDifferenceDataProvider()
+    {
+        return array(
+            array("2014-04-26 13:00:00", "2014-04-26 12:58:15", '1 minute, 45 seconds ago'),
+            array("2014-04-26 13:00:00", "2014-04-26 11:20:00", '1 hour, 40 minutes ago'),
+            array("2014-04-26 13:00:00", "2014-04-27 13:15:00", '1 day, 15 minutes from now'),
+            array("2014-04-26 13:00:00", "2014-05-03 15:00:00", '7 days, 2 hours from now'),
+            array("2014-04-26 13:00:00", "2015-04-28 17:00:00", '1 year, 2 days, 4 hours from now'),
+            array("2014-04-26 13:00:00", "2014-04-28 23:00:00", '2 days, 10 hours from now'),
+            array("2014-04-26 13:00:00", "2014-04-25 11:20:00", '1 day, 1 hour, 40 minutes ago'),
+            array("2014-04-26 13:00:00", "2016-04-27 13:00:00", '2 years, 1 day from now'),
+
+            array("2014-04-26 13:00:00", "2014-04-26 12:58:15", '1 minuta, 45 sekund temu', 'pl'),
+            array("2014-04-26 13:00:00", "2014-04-26 11:20:00", '1 godzina, 40 minut temu', 'pl'),
+            array("2014-04-26 13:00:00", "2014-04-27 13:15:00", '1 dzień, 15 minut od teraz', 'pl'),
+            array("2014-04-26 13:00:00", "2014-05-03 15:00:00", '7 dni, 2 godziny od teraz', 'pl'),
+            array("2014-04-26 13:00:00", "2015-04-28 17:00:00", '1 rok, 2 dni, 4 godziny od teraz', 'pl'),
+            array("2014-04-26 13:00:00", "2014-04-28 23:00:00", '2 dni, 10 godzin od teraz', 'pl'),
+            array("2014-04-26 13:00:00", "2014-04-25 11:20:00", '1 dzień, 1 godzina, 40 minut temu', 'pl'),
+            array("2014-04-26 13:00:00", "2016-04-27 13:00:00", '2 lata, 1 dzień od teraz', 'pl'),
+
+            array("2014-04-26 13:00:00", "2014-04-26 12:58:15", '1 Minute, 45 Sekunden vor', 'de'),
+            array("2014-04-26 13:00:00", "2014-04-26 11:20:00", '1 Stunde, 40 Minuten vor', 'de'),
+            array("2014-04-26 13:00:00", "2014-04-27 13:15:00", '1 Tag, 15 Minuten ab jetzt', 'de'),
+            array("2014-04-26 13:00:00", "2014-05-03 15:00:00", '7 Tage, 2 Stunden ab jetzt', 'de'),
+            array("2014-04-26 13:00:00", "2015-04-28 17:00:00", '1 Jahr, 2 Tage, 4 Stunden ab jetzt', 'de'),
+            array("2014-04-26 13:00:00", "2014-04-28 23:00:00", '2 Tage, 10 Stunden ab jetzt', 'de'),
+            array("2014-04-26 13:00:00", "2014-04-25 11:20:00", '1 Tag, 1 Stunde, 40 Minuten vor', 'de'),
+            array("2014-04-26 13:00:00", "2016-04-27 13:00:00", '2 Jahre, 1 Tag ab jetzt', 'de'),
+
+            array("2014-04-26 13:00:00", "2014-04-26 12:58:15", '1 dakika, 45 saniye önce', 'tr'),
+            array("2014-04-26 13:00:00", "2014-04-26 11:20:00", '1 saat, 40 dakika önce', 'tr'),
+            array("2014-04-26 13:00:00", "2014-04-27 13:15:00", '1 gün, 15 dakika sonra', 'tr'),
+            array("2014-04-26 13:00:00", "2014-05-03 15:00:00", '7 gün, 2 saat sonra', 'tr'),
+            array("2014-04-26 13:00:00", "2015-04-28 17:00:00", '1 yıl, 2 gün, 4 saat sonra', 'tr'),
+            array("2014-04-26 13:00:00", "2014-04-28 23:00:00", '2 gün, 10 saat sonra', 'tr'),
+            array("2014-04-26 13:00:00", "2014-04-25 11:20:00", '1 gün, 1 saat, 40 dakika önce', 'tr'),
+            array("2014-04-26 13:00:00", "2016-04-27 13:00:00", '2 yıl, 1 gün sonra', 'tr'),
+
+            array("2014-04-26 13:00:00", "2014-04-26 12:58:15", '1 minute, 45 secondes il y a', 'fr'),
+            array("2014-04-26 13:00:00", "2014-04-26 11:20:00", '1 heure, 40 minutes il y a', 'fr'),
+            array("2014-04-26 13:00:00", "2014-04-27 13:15:00", '1 jour, 15 minutes maintenant', 'fr'),
+            array("2014-04-26 13:00:00", "2014-05-03 15:00:00", '7 jours, 2 heures maintenant', 'fr'),
+            array("2014-04-26 13:00:00", "2015-04-28 17:00:00", '1 année, 2 jours, 4 heures maintenant', 'fr'),
+            array("2014-04-26 13:00:00", "2014-04-28 23:00:00", '2 jours, 10 heures maintenant', 'fr'),
+            array("2014-04-26 13:00:00", "2014-04-25 11:20:00", '1 jour, 1 heure, 40 minutes il y a', 'fr'),
+            array("2014-04-26 13:00:00", "2016-04-27 13:00:00", '2 années, 1 jour maintenant', 'fr'),
+
+            array("2014-04-26 13:00:00", "2014-04-26 12:58:15", '1 minuto, 45 segundos atrás', 'pt_BR'),
+            array("2014-04-26 13:00:00", "2014-04-26 11:20:00", '1 hora, 40 minutos atrás', 'pt_BR'),
+            array("2014-04-26 13:00:00", "2014-04-27 13:15:00", '1 dia, 15 minutos a partir de agora', 'pt_BR'),
+            array("2014-04-26 13:00:00", "2014-05-03 15:00:00", '7 dias, 2 horas a partir de agora', 'pt_BR'),
+            array("2014-04-26 13:00:00", "2015-04-28 17:00:00", '1 ano, 2 dias, 4 horas a partir de agora', 'pt_BR'),
+            array("2014-04-26 13:00:00", "2014-04-28 23:00:00", '2 dias, 10 horas a partir de agora', 'pt_BR'),
+            array("2014-04-26 13:00:00", "2014-04-25 11:20:00", '1 dia, 1 hora, 40 minutos atrás', 'pt_BR'),
+            array("2014-04-26 13:00:00", "2016-04-27 13:00:00", '2 anos, 1 dia a partir de agora', 'pt_BR'),
+
+            array("2014-04-26 13:00:00", "2014-04-26 12:58:15", '1 minuto, 45 secondi fa', 'it'),
+            array("2014-04-26 13:00:00", "2014-04-26 11:20:00", '1 ora, 40 minuti fa', 'it'),
+            array("2014-04-26 13:00:00", "2014-04-27 13:15:00", '1 giorno, 15 minuti da adesso', 'it'),
+            array("2014-04-26 13:00:00", "2014-05-03 15:00:00", '7 giorni, 2 ore da adesso', 'it'),
+            array("2014-04-26 13:00:00", "2015-04-28 17:00:00", '1 anno, 2 giorni, 4 ore da adesso', 'it'),
+            array("2014-04-26 13:00:00", "2014-04-28 23:00:00", '2 giorni, 10 ore da adesso', 'it'),
+            array("2014-04-26 13:00:00", "2014-04-25 11:20:00", '1 giorno, 1 ora, 40 minuti fa', 'it'),
+            array("2014-04-26 13:00:00", "2016-04-27 13:00:00", '2 anni, 1 giorno da adesso', 'it'),
+        );
+    }
+}

--- a/tests/unit/NumberTest.php
+++ b/tests/unit/NumberTest.php
@@ -1,0 +1,295 @@
+<?php
+
+namespace Coduo\PHPHumanizer\Tests;
+
+use Coduo\PHPHumanizer\Number;
+use InvalidArgumentException;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * Class NumberTest
+ *
+ * @package Coduo\PHPHumanizer\Tests
+ */
+class NumberTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider ordinalSuffixProvider
+     *
+     * @param $expected
+     * @param $number
+     */
+    public function test_return_ordinal_suffix($expected, $number)
+    {
+        $numberobj = new Number();
+
+        $this->assertEquals($expected, $numberobj->ordinal($number));
+        $this->assertEquals($expected, Number::ordinal($number));
+    }
+
+    /**
+     * @dataProvider ordinalizeDataProvider
+     * @depends test_return_ordinal_suffix
+     *
+     * @param $expected
+     * @param $number
+     */
+    public function test_ordinalize_numbers($expected, $number)
+    {
+        $numberobj = new Number();
+
+        $this->assertEquals($expected, $numberobj->ordinalize($number));
+        $this->assertEquals($expected, Number::ordinalize($number));
+    }
+
+    /**
+     * @dataProvider binarySuffixDataProvider
+     *
+     * @param        $expected
+     * @param        $number
+     * @param string $locale
+     */
+    public function test_convert_number_to_string_with_binary_suffix($expected, $number, $locale = 'en')
+    {
+        $numberobj = new Number();
+
+        $this->assertEquals($expected, $numberobj->binarySuffix($number, $locale));
+        $this->assertEquals($expected, Number::binarySuffix($number, $locale));
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function test_non_statically_throw_exception_when_converting_to_string_with_binary_suffix_non_numeric_values()
+    {
+        $numberobj = new Number();
+
+        $numberobj->binarySuffix('as12');
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function test_statically_throw_exception_when_converting_to_string_with_binary_suffix_non_numeric_values()
+    {
+        Number::binarySuffix('as12');
+    }
+
+    /**
+     * @dataProvider metricSuffixDataProvider
+     *
+     * @param        $expected
+     * @param        $number
+     * @param string $locale
+     */
+    public function test_convert_number_to_string_with_metric_suffix($expected, $number, $locale = 'en')
+    {
+        $numberobj = new Number();
+
+        $this->assertEquals($expected, $numberobj->metricSuffix($number, $locale));
+        $this->assertEquals($expected, Number::metricSuffix($number, $locale));
+    }
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function test_non_statically_throw_exception_when_converting_to_string_with_metric_suffix_non_numeric_values()
+    {
+        $numberobj = new Number();
+
+        $numberobj->metricSuffix('as12');
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function test_statically_throw_exception_when_converting_to_string_with_metric_suffix_non_numeric_values()
+    {
+        Number::metricSuffix('as12');
+    }
+
+    /**
+     * @dataProvider romanDataProvider
+     *
+     * @param $expected
+     * @param $number
+     */
+    public function test_converts_numbers_to_roman($expected, $number)
+    {
+        $numberobj = new Number();
+
+        $this->assertEquals($expected, $numberobj->toRoman($number));
+        $this->assertEquals($expected, Number::toRoman($number));
+    }
+
+    /**
+     * @dataProvider romanDataProvider
+     *
+     * @param $expected
+     * @param $number
+     */
+    public function test_convert_roman_numbers_to_arabic($number, $expected)
+    {
+        $numberobj = new Number();
+
+        $this->assertEquals($expected, $numberobj->fromRoman($number));
+        $this->assertEquals($expected, Number::fromRoman($number));
+    }
+
+    /**
+     * @dataProvider romanExceptionProvider
+     * @expectedException InvalidArgumentException
+     *
+     * @param $number
+     */
+    public function test_non_statically_throw_exception_when_converting_number_is_out_of_range($number)
+    {
+        $numberobj = new Number();
+
+        $numberobj->toRoman($number);
+    }
+
+    /**
+     * @dataProvider romanExceptionProvider
+     * @expectedException InvalidArgumentException
+     *
+     * @param $number
+     */
+    public function test_statically_throw_exception_when_converting_number_is_out_of_range($number)
+    {
+        Number::toRoman($number);
+    }
+
+    /**
+     * @dataProvider arabicExceptionProvider
+     * @expectedException InvalidArgumentException
+     *
+     * @param $number
+     */
+    public function test_non_statically_throw_exception_when_converting_roman_number_is_invalid($number)
+    {
+        $numberobj = new Number();
+
+        $numberobj->fromRoman($number);
+    }
+
+    /**
+     * @dataProvider arabicExceptionProvider
+     * @expectedException InvalidArgumentException
+     *
+     * @param $number
+     */
+    public function test_statically_throw_exception_when_converting_roman_number_is_invalid($number)
+    {
+        Number::fromRoman($number);
+    }
+
+    /**
+     * @return array
+     */
+    public function ordinalizeDataProvider()
+    {
+        return array(
+            array('1st', 1),
+            array('2nd', 2),
+            array('23rd', 23),
+            array('1002nd', 1002),
+            array('-111th', -111),
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function ordinalSuffixProvider()
+    {
+        return array(
+            array('st', 1),
+            array('nd', 2),
+            array('rd', 23),
+            array('nd', 1002),
+            array('th', -111),
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function binarySuffixDataProvider()
+    {
+        return array(
+            array(-1, -1),
+            array("0 bytes", 0),
+            array("1 bytes", 1),
+            array("1 kB", 1024),
+            array("1 kB", 1025),
+            array("1.5 kB", 1536),
+            array("5 MB", 1048576 * 5),
+            array("2 GB", 1073741824 * 2),
+            array("3 TB", 1099511627776 * 3),
+            array("1.18 PB", 1325899906842624),
+
+            array("1,5 kB", 1536, 'pl'),
+            array("1,18 PB", 1325899906842624, 'pl'),
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function metricSuffixDataProvider()
+    {
+        return array(
+            array("-1", -1),
+            array("0", 0),
+            array("1", 1),
+            array("101", 101),
+            array("1k", 1000),
+            array("1.2k", 1240),
+            array("1.24M", 1240000),
+            array("3.5M", 3500000),
+
+            array("1,2k", 1240, 'pl'),
+            array("1,24M", 1240000, 'pl'),
+            array("3,5M", 3500000, 'pl'),
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function romanDataProvider()
+    {
+        return array(
+            array("I", 1),
+            array("V", 5),
+            array("IX", 9),
+            array("X", 10),
+            array("CXXV", 125),
+            array("MCCC", 1300),
+            array("MMMCMXCIX", 3999),
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function romanExceptionProvider()
+    {
+        return array(
+            array(-1),
+            array(4000),
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function arabicExceptionProvider()
+    {
+        return array(
+            array(1234),
+            array(""),
+            array("foobar"),
+        );
+    }
+}

--- a/tests/unit/StringTest.php
+++ b/tests/unit/StringTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Coduo\PHPHumanizer\Tests;
+
+use Coduo\PHPHumanizer\String;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * Class StringTest
+ *
+ * @package Coduo\PHPHumanizer\Tests
+ */
+class StringTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider humanizeStringProvider
+     *
+     * @param $input
+     * @param $expected
+     * @param $capitalize
+     */
+    public function test_humanize_strings($input, $expected, $capitalize = true)
+    {
+        $string = new String();
+
+        $this->assertEquals($expected, $string->humanize($input, $capitalize));
+        $this->assertEquals($expected, String::humanize($input, $capitalize));
+    }
+
+    /**
+     * @dataProvider truncateStringProvider
+     *
+     * @param        $text
+     * @param        $expected
+     * @param        $charactersCount
+     * @param string $append
+     */
+    function test_truncate_string_to_word_closest_to_a_certain_number_of_characters($text, $expected, $charactersCount, $append = '')
+    {
+        $string = new String();
+
+        $this->assertEquals($expected, $string->truncate($text, $charactersCount, $append));
+        $this->assertEquals($expected, String::truncate($text, $charactersCount, $append));
+    }
+
+    /**
+     *
+     * @return array
+     */
+    public function humanizeStringProvider()
+    {
+        return array(
+            array('news_count', 'News count'),
+            array('user', 'user', false),
+            array('news_id', 'News'),
+            array('news_count', 'News count'),
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function truncateStringProvider()
+    {
+        return array(
+            array('Lorem ipsum dolorem si amet, lorem ipsum. Dolorem sic et nunc.', 'Lorem', 2),
+            array('Lorem ipsum dolorem si amet, lorem ipsum. Dolorem sic et nunc.', 'Lorem ipsum...', 10, '...'),
+            array('Lorem ipsum dolorem si amet, lorem ipsum. Dolorem sic et nunc.', 'Lorem ipsum dolorem si amet, lorem', 30),
+            array('Lorem ipsum dolorem si amet, lorem ipsum. Dolorem sic et nunc.', 'Lorem', 0),
+            array('Lorem ipsum dolorem si amet, lorem ipsum. Dolorem sic et nunc.', 'Lorem...', 0, '...'),
+            array('Lorem ipsum dolorem si amet, lorem ipsum. Dolorem sic et nunc.', 'Lorem ipsum dolorem si amet, lorem ipsum. Dolorem sic et nunc.', -2),
+        );
+    }
+}


### PR DESCRIPTION
First I wanted to change the library to make it possible to call the methods non-statically, after doing so I could not figure out why phpspec was not throwing any errors as it should, so I rewrote all the specs in phpunit.

Then I found out PHP allows you to call static methods non-statically so all my work was for nothing, or so I thought!

phpunit found that the fromRoman method in the Number class was not static and so not allowed to be called statically.

So, this pull request adds a lot of phpunit tests that found a bug that phpspec somehow missed and fixes a very tiny bug!