### PR TITLE
Force $binaryPrefixes array ordering on 32-bit systems, fixes #83

### DIFF
--- a/src/Coduo/PHPHumanizer/String/BinarySuffix.php
+++ b/src/Coduo/PHPHumanizer/String/BinarySuffix.php
@@ -47,6 +47,12 @@ final class BinarySuffix
 
         $this->number = (int) $number;
         $this->locale = $locale;
+
+        /*
+         * Workaround for 32-bit systems which ignore array ordering when
+         * dropping values over 2^32-1
+         */
+        krsort($this->binaryPrefixes);
     }
 
     public function convert()

--- a/src/Coduo/PHPHumanizer/String/MetricSuffix.php
+++ b/src/Coduo/PHPHumanizer/String/MetricSuffix.php
@@ -42,6 +42,12 @@ final class MetricSuffix
 
         $this->number = (int) $number;
         $this->locale = $locale;
+
+        /*
+         * Workaround for 32-bit systems which ignore array ordering when
+         * dropping values over 2^32-1
+         */
+        krsort($this->binaryPrefixes);
     }
 
     public function convert()


### PR DESCRIPTION
This fixes an issue when a 32-bit system breaks associative array ordering when dropping keys over 2^32-1 in `String\BinarySuffix` and `String\MetricSuffix`

As noted by @mikaelcom, the following array:

```php
private $binaryPrefixes = array(
    1125899906842624 => '#.## PB',
    1099511627776 => '#.## TB',
    1073741824 => '#.## GB',
    1048576 => '#.## MB',
    1024 => '#.# kB',
    0 => '# bytes',
);
```

in `String\BinarySuffix` becomes:

```php
array(4) {
    [0] =>
    string(7) "# bytes"
    [1073741824] =>
    string(7) "#.## GB"
    [1048576] =>
    string(7) "#.## MB"
    [1024] =>
    string(6) "#.# kB"
}
```

during runtime on 32-bit systems. This breaks the conversion logic, causing a `Division by zero` exception.

The introduced change sorts the associative array with `krsort()` so that it gets ordered properly:

```php
array(4) {
    [1073741824] =>
    string(7) "#.## GB"
    [1048576] =>
    string(7) "#.## MB"
    [1024] =>
    string(6) "#.# kB"
    [0] =>
    string(7) "# bytes"
}
```

*Tested on:* Ubuntu 14.04.5, kernel 4.4.0-42-generic i686, PHP 5.5.9-1ubuntu4.20.

Should be tested on other architectures and with other values, but I don't think there are any negative consequences to this change.