### PR TITLE
Upgrade Shortcode library to v0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,15 @@ StringHumanizer::truncateHtml($text, 75, '<b><i><u><em><strong><a><span>', '...'
 
 ```
 
+**Remove shortcodes**
+
+```php
+$text = 'A text with [short]random[/short] [codes]words[/codes].';
+
+StringHumanizer::removeShortcodes($text); // "A text with ."
+StringHumanizer::removeShortcodeTags($text); // "A text with random words."
+```
+
 ## Number
 
 **Ordinalize**

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/yaml": "^2.3|^3.0"
     },
     "require-dev": {
-        "thunderer/shortcode": "~0.5",
+        "thunderer/shortcode": "^0.6",
         "phpspec/phpspec": "^2",
         "phpunit/phpunit": "^4.5|^5.0"
     },

--- a/src/Coduo/PHPHumanizer/StringHumanizer.php
+++ b/src/Coduo/PHPHumanizer/StringHumanizer.php
@@ -59,9 +59,9 @@ final class StringHumanizer
     public static function removeShortcodes($text)
     {
         if (!class_exists('Thunder\Shortcode\Processor\Processor')) {
-            throw new \RuntimeException("Please add \"thunderer/shortcode\": ~0.5 to composer.json first");
+            throw new \RuntimeException("Please add \"thunderer/shortcode\": ^0.6 to composer.json first");
         }
-        
+
         $processor = new ShortcodeProcessor();
 
         return $processor->removeShortcodes($text);
@@ -74,9 +74,9 @@ final class StringHumanizer
     public static function removeShortcodeTags($text)
     {
         if (!class_exists('Thunder\Shortcode\Processor\Processor')) {
-            throw new \RuntimeException("Please add \"thunderer/shortcode\": ~0.5 to composer.json first");
+            throw new \RuntimeException("Please add \"thunderer/shortcode\": ^0.6 to composer.json first");
         }
-        
+
         $processor = new ShortcodeProcessor();
 
         return $processor->removeShortcodeTags($text);


### PR DESCRIPTION
I released Shortcode `v0.6` in February since then it also gained new features and fixes. There are no BC breaks, so Humanizer can be safely upgraded to use the recent release. I also added a small section of README to explain the functionality provided by my library.