### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-#A quick guide to contribute to the project:
+# A quick guide to contribute to the project:
 
-##Installing the dev environment
+## Installing the dev environment
 
 1.  Fork the repo
 2.  Clone the repo to local
@@ -8,13 +8,13 @@
 4.  Run the tests. We only take pull requests with passing tests, and it's great to know that you have a clean slate:
     `./bin/phpspec run --format=pretty`
 
-##The actual contribution
+## The actual contribution
 
 1.  Make the changes/additions to the code, committing often and making clear what you've done
 2.  Make sure you write tests for your code, located in the folder structure `spec/Coduo/PHPHumanizer/...`
 3.  Run your tests (often and while coding): `./bin/phpspec run --format=pretty`
 
-##Coding Standards
+## Coding Standards
 
 Try use similar coding standards to what you see in the project to keep things clear to the contributors. If you're unsure, it's always a safe bet to fall-back to the PSR standards.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#PHP Humanizer
+# PHP Humanizer
 
 [![Build Status](https://travis-ci.org/coduo/php-humanizer.svg?branch=master)](https://travis-ci.org/coduo/php-humanizer)
 [![Latest Stable Version](https://poser.pugx.org/coduo/php-humanizer/v/stable)](https://packagist.org/packages/coduo/php-humanizer)
@@ -8,7 +8,7 @@
 
 Humanize values to make them readable for regular people ;)
 
-#Installation
+# Installation
 
 Run the following command:
 
@@ -16,7 +16,7 @@ Run the following command:
 composer require coduo/php-humanizer
 ```
 
-#Usage
+# Usage
 
 ## Text
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
