### PR TITLE
Upgraded thunderer/shortcode dependency to ^0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ StringHumanizer::truncateHtml($text, 75, '<b><i><u><em><strong><a><span>', '...'
 
 ```
 
+**Remove shortcodes**
+
+```php
+$text = 'A text with [short]random[/short] [codes]words[/codes].';
+StringHumanizer::removeShortcodes($text); // "A text with ."
+StringHumanizer::removeShortcodeTags($text); // "A text with random words."
+```
+
 ## Number
 
 **Ordinalize**

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "friendsofphp/php-cs-fixer": "^2.14"
     },
     "require-dev": {
-        "thunderer/shortcode": "~0.5",
+        "thunderer/shortcode": "^0.7",
         "phpspec/phpspec": "^2",
         "phpunit/phpunit": "^4.5|^5.0"
     },

--- a/src/Coduo/PHPHumanizer/StringHumanizer.php
+++ b/src/Coduo/PHPHumanizer/StringHumanizer.php
@@ -60,10 +60,10 @@ final class StringHumanizer
      */
     public static function removeShortcodes($text)
     {
-        if (!\class_exists('Thunder\Shortcode\Processor\Processor')) {
-            throw new \RuntimeException('Please add "thunderer/shortcode": ~0.5 to composer.json first');
+        if (!class_exists('Thunder\Shortcode\Processor\Processor')) {
+            throw new \RuntimeException('Please add "thunderer/shortcode": ^0.7 to composer.json first');
         }
-        
+
         $processor = new ShortcodeProcessor();
 
         return $processor->removeShortcodes($text);
@@ -75,10 +75,10 @@ final class StringHumanizer
      */
     public static function removeShortcodeTags($text)
     {
-        if (!\class_exists('Thunder\Shortcode\Processor\Processor')) {
-            throw new \RuntimeException('Please add "thunderer/shortcode": ~0.5 to composer.json first');
+        if (!class_exists('Thunder\Shortcode\Processor\Processor')) {
+            throw new \RuntimeException('Please add "thunderer/shortcode": ^0.7 to composer.json first');
         }
-        
+
         $processor = new ShortcodeProcessor();
 
         return $processor->removeShortcodeTags($text);


### PR DESCRIPTION
Shortcode latest version is `v0.7`. There are no BC breaks, so Humanizer can be safely upgraded to use the recent release. I also added a small section of README to explain the functionality provided by my library. This is an update to already closed PR #90.