### PR TITLE
Using assertSame to make assertEquals restricted

### DIFF
--- a/tests/Coduo/PHPHumanizer/Tests/CollectionHumanizerTest.php
+++ b/tests/Coduo/PHPHumanizer/Tests/CollectionHumanizerTest.php
@@ -21,7 +21,7 @@ final class CollectionHumanizerTest extends TestCase
      */
     public function test_oxford_collections_humanizing($collection, $limit, $locale, $expectedResult) : void
     {
-        $this->assertEquals($expectedResult, CollectionHumanizer::oxford($collection, $limit, $locale));
+        $this->assertSame($expectedResult, CollectionHumanizer::oxford($collection, $limit, $locale));
     }
 
     public function oxfordCollectionProvider()

--- a/tests/Coduo/PHPHumanizer/Tests/DateTimeHumanizerTest.php
+++ b/tests/Coduo/PHPHumanizer/Tests/DateTimeHumanizerTest.php
@@ -26,7 +26,7 @@ class DateTimeHumanizerTest extends TestCase
      */
     public function test_humanize_difference_between_dates(string $firstDate, string $secondDate, string $expected, string $locale) : void
     {
-        $this->assertEquals($expected, DateTimeHumanizer::difference(new \DateTime($firstDate), new \DateTime($secondDate), $locale));
+        $this->assertSame($expected, DateTimeHumanizer::difference(new \DateTime($firstDate), new \DateTime($secondDate), $locale));
     }
 
     /**
@@ -34,7 +34,7 @@ class DateTimeHumanizerTest extends TestCase
      */
     public function test_humanize_time_period(string $firstDate, string $secondDate, string $expected, string $locale) : void
     {
-        $this->assertEquals($expected, DateTimeHumanizer::timePeriod(new TimePeriod(DateTime::fromString($firstDate), DateTime::fromString($secondDate)), $locale));
+        $this->assertSame($expected, DateTimeHumanizer::timePeriod(new TimePeriod(DateTime::fromString($firstDate), DateTime::fromString($secondDate)), $locale));
     }
 
     /**
@@ -42,7 +42,7 @@ class DateTimeHumanizerTest extends TestCase
      */
     public function test_humanize_precise_difference_between_dates(string $firstDate, string $secondDate, string $expected, string $locale) : void
     {
-        $this->assertEquals($expected, DateTimeHumanizer::timePeriodPrecise(new TimePeriod(DateTime::fromString($firstDate), DateTime::fromString($secondDate)), $locale));
+        $this->assertSame($expected, DateTimeHumanizer::timePeriodPrecise(new TimePeriod(DateTime::fromString($firstDate), DateTime::fromString($secondDate)), $locale));
     }
 
     /**
@@ -50,7 +50,7 @@ class DateTimeHumanizerTest extends TestCase
      */
     public function test_humanize_time_period_precise(string $firstDate, string $secondDate, string $expected, string $locale) : void
     {
-        $this->assertEquals($expected, DateTimeHumanizer::preciseDifference(new \DateTime($firstDate), new \DateTime($secondDate), $locale));
+        $this->assertSame($expected, DateTimeHumanizer::preciseDifference(new \DateTime($firstDate), new \DateTime($secondDate), $locale));
     }
 
     /**

--- a/tests/Coduo/PHPHumanizer/Tests/NumberHumanizerTest.php
+++ b/tests/Coduo/PHPHumanizer/Tests/NumberHumanizerTest.php
@@ -24,7 +24,7 @@ class NumberHumanizerTest extends TestCase
      */
     public function test_return_ordinal_suffix($expected, $number) : void
     {
-        $this->assertEquals($expected, NumberHumanizer::ordinal($number));
+        $this->assertSame($expected, NumberHumanizer::ordinal($number));
     }
 
     /**
@@ -35,7 +35,7 @@ class NumberHumanizerTest extends TestCase
      */
     public function test_return_ordinal_suffix_dutch($expected, $number) : void
     {
-        $this->assertEquals($expected, NumberHumanizer::ordinal($number, 'nl'));
+        $this->assertSame($expected, NumberHumanizer::ordinal($number, 'nl'));
     }
 
     /**
@@ -46,7 +46,7 @@ class NumberHumanizerTest extends TestCase
      */
     public function test_return_ordinal_suffix_indonesian($expected, $number) : void
     {
-        $this->assertEquals($expected, NumberHumanizer::ordinal($number, 'id'));
+        $this->assertSame($expected, NumberHumanizer::ordinal($number, 'id'));
     }
 
     /**
@@ -57,7 +57,7 @@ class NumberHumanizerTest extends TestCase
      */
     public function test_return_ordinal_suffix_spanish($expected, $number) : void
     {
-        $this->assertEquals($expected, NumberHumanizer::ordinal($number, 'es'));
+        $this->assertSame($expected, NumberHumanizer::ordinal($number, 'es'));
     }
 
     /**
@@ -68,7 +68,7 @@ class NumberHumanizerTest extends TestCase
      */
     public function test_return_ordinal_suffix_italian($expected, $number) : void
     {
-        $this->assertEquals($expected, NumberHumanizer::ordinal($number, 'it'));
+        $this->assertSame($expected, NumberHumanizer::ordinal($number, 'it'));
     }
 
     /**
@@ -79,7 +79,7 @@ class NumberHumanizerTest extends TestCase
      */
     public function test_return_ordinal_suffix_german($expected, $number) : void
     {
-        $this->assertEquals($expected, NumberHumanizer::ordinal($number, 'de'));
+        $this->assertSame($expected, NumberHumanizer::ordinal($number, 'de'));
     }
 
     /**
@@ -90,7 +90,7 @@ class NumberHumanizerTest extends TestCase
      */
     public function test_return_ordinal_suffix_french($expected, $number) : void
     {
-        $this->assertEquals($expected, NumberHumanizer::ordinal($number, 'fr'));
+        $this->assertSame($expected, NumberHumanizer::ordinal($number, 'fr'));
     }
 
     /**
@@ -102,7 +102,7 @@ class NumberHumanizerTest extends TestCase
      */
     public function test_ordinalize_numbers($expected, $number) : void
     {
-        $this->assertEquals($expected, NumberHumanizer::ordinalize($number));
+        $this->assertSame($expected, NumberHumanizer::ordinalize($number));
     }
 
     /**
@@ -114,7 +114,7 @@ class NumberHumanizerTest extends TestCase
      */
     public function test_ordinalize_numbers_dutch($expected, $number) : void
     {
-        $this->assertEquals($expected, NumberHumanizer::ordinalize($number, 'nl'));
+        $this->assertSame($expected, NumberHumanizer::ordinalize($number, 'nl'));
     }
 
     /**
@@ -126,7 +126,7 @@ class NumberHumanizerTest extends TestCase
      */
     public function test_ordinalize_numbers_indonesian($expected, $number) : void
     {
-        $this->assertEquals($expected, NumberHumanizer::ordinalize($number, 'id'));
+        $this->assertSame($expected, NumberHumanizer::ordinalize($number, 'id'));
     }
 
     /**
@@ -137,7 +137,7 @@ class NumberHumanizerTest extends TestCase
      */
     public function test_ordinalize_numbers_portuguese($expected, $number) : void
     {
-        $this->assertEquals($expected, NumberHumanizer::ordinalize($number, 'pt'));
+        $this->assertSame($expected, NumberHumanizer::ordinalize($number, 'pt'));
     }
 
     /**
@@ -148,7 +148,7 @@ class NumberHumanizerTest extends TestCase
      */
     public function test_ordinalize_numbers_spanish($expected, $number) : void
     {
-        $this->assertEquals($expected, NumberHumanizer::ordinalize($number, 'es'));
+        $this->assertSame($expected, NumberHumanizer::ordinalize($number, 'es'));
     }
 
     /**
@@ -159,7 +159,7 @@ class NumberHumanizerTest extends TestCase
      */
     public function test_ordinalize_numbers_italian($expected, $number) : void
     {
-        $this->assertEquals($expected, NumberHumanizer::ordinalize($number, 'it'));
+        $this->assertSame($expected, NumberHumanizer::ordinalize($number, 'it'));
     }
 
     /**
@@ -170,7 +170,7 @@ class NumberHumanizerTest extends TestCase
      */
     public function test_ordinalize_numbers_german($expected, $number) : void
     {
-        $this->assertEquals($expected, NumberHumanizer::ordinalize($number, 'de'));
+        $this->assertSame($expected, NumberHumanizer::ordinalize($number, 'de'));
     }
 
     /**
@@ -181,7 +181,7 @@ class NumberHumanizerTest extends TestCase
      */
     public function test_ordinalize_numbers_french($expected, $number) : void
     {
-        $this->assertEquals($expected, NumberHumanizer::ordinalize($number, 'fr'));
+        $this->assertSame($expected, NumberHumanizer::ordinalize($number, 'fr'));
     }
 
     /**
@@ -193,7 +193,7 @@ class NumberHumanizerTest extends TestCase
      */
     public function test_convert_number_to_string_with_binary_suffix($expected, $number, $locale = 'en') : void
     {
-        $this->assertEquals($expected, NumberHumanizer::binarySuffix($number, $locale));
+        $this->assertSame($expected, NumberHumanizer::binarySuffix($number, $locale));
     }
 
     /**
@@ -206,7 +206,7 @@ class NumberHumanizerTest extends TestCase
      */
     public function test_convert_number_to_string_with_precise_binary_suffix($expected, $number, $precision, $locale = 'en') : void
     {
-        $this->assertEquals($expected, NumberHumanizer::preciseBinarySuffix($number, $precision, $locale));
+        $this->assertSame($expected, NumberHumanizer::preciseBinarySuffix($number, $precision, $locale));
     }
 
     public function test_statically_throw_exception_when_converting_to_string_with_precise_binary_suffix_negative_precision() : void
@@ -232,7 +232,7 @@ class NumberHumanizerTest extends TestCase
      */
     public function test_convert_number_to_string_with_metric_suffix($expected, $number, $locale = 'en') : void
     {
-        $this->assertEquals($expected, NumberHumanizer::metricSuffix($number, $locale));
+        $this->assertSame($expected, NumberHumanizer::metricSuffix($number, $locale));
     }
 
     public function test_statically_throw_exception_when_converting_to_string_with_metric_suffix_non_numeric_values() : void
@@ -250,7 +250,7 @@ class NumberHumanizerTest extends TestCase
      */
     public function test_converts_numbers_to_roman($expected, $number) : void
     {
-        $this->assertEquals($expected, NumberHumanizer::toRoman($number));
+        $this->assertSame($expected, NumberHumanizer::toRoman($number));
     }
 
     /**
@@ -261,7 +261,7 @@ class NumberHumanizerTest extends TestCase
      */
     public function test_convert_roman_numbers_to_arabic($number, $expected) : void
     {
-        $this->assertEquals($expected, NumberHumanizer::fromRoman($number));
+        $this->assertSame($expected, NumberHumanizer::fromRoman($number));
     }
 
     /**

--- a/tests/Coduo/PHPHumanizer/Tests/StringHumanizerTest.php
+++ b/tests/Coduo/PHPHumanizer/Tests/StringHumanizerTest.php
@@ -27,7 +27,7 @@ class StringHumanizerTest extends TestCase
      */
     public function test_humanize_strings($input, $expected, $capitalize, $separator, array $forbiddenWords) : void
     {
-        $this->assertEquals($expected, StringHumanizer::humanize($input, $capitalize, $separator, $forbiddenWords));
+        $this->assertSame($expected, StringHumanizer::humanize($input, $capitalize, $separator, $forbiddenWords));
     }
 
     /**
@@ -40,7 +40,7 @@ class StringHumanizerTest extends TestCase
      */
     public function test_truncate_string_to_word_closest_to_a_certain_number_of_characters($text, $expected, $charactersCount, $append = '') : void
     {
-        $this->assertEquals($expected, StringHumanizer::truncate($text, $charactersCount, $append));
+        $this->assertSame($expected, StringHumanizer::truncate($text, $charactersCount, $append));
     }
 
     /**
@@ -54,7 +54,7 @@ class StringHumanizerTest extends TestCase
      */
     public function test_truncate_string_to_word_closest_to_a_certain_number_of_characters_with_html_tags($text, $charactersCount, $allowedTags, $expected, $append = '') : void
     {
-        $this->assertEquals($expected, StringHumanizer::truncateHtml($text, $charactersCount, $allowedTags, $append));
+        $this->assertSame($expected, StringHumanizer::truncateHtml($text, $charactersCount, $allowedTags, $append));
     }
 
     /**
@@ -65,7 +65,7 @@ class StringHumanizerTest extends TestCase
      */
     public function test_remove_all_shortcodes_from_text($text, $expected) : void
     {
-        $this->assertEquals($expected, StringHumanizer::removeShortcodes($text));
+        $this->assertSame($expected, StringHumanizer::removeShortcodes($text));
     }
 
     /**
@@ -76,7 +76,7 @@ class StringHumanizerTest extends TestCase
      */
     public function test_remove_only_shortcode_tags_from_text($text, $expected) : void
     {
-        $this->assertEquals($expected, StringHumanizer::removeShortcodeTags($text));
+        $this->assertSame($expected, StringHumanizer::removeShortcodeTags($text));
     }
 
     public function removeAllShortcodesProvider()


### PR DESCRIPTION
<h2>Change Log</h2>
<div id="change-log">
  <h4>Changed</h4>
  <ul id="changed">
    <li>Using the assertSame to make assert equals restricted.</li>
  </ul>
</div>
<hr/>

<h2>Description</h2>

- Using the assertSame to replace assertEquals and it can make assert equals restricted.