### PR TITLE
Fix CI status badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License](https://poser.pugx.org/coduo/php-humanizer/license)](https://packagist.org/packages/coduo/php-humanizer)
 
 ### Tests
-* [![Build Status](https://travis-ci.com/coduo/php-humanizer.svg?branch=4.x)](https://travis-ci.com/coduo/php-humanizer) - 4.x 
+* ![Tests](https://github.com/coduo/php-humanizer/workflows/Tests/badge.svg?branch=4.x) - 4.x
 
 [Readme for 4.x version](https://github.com/coduo/php-humanizer/tree/4.x/README.md)  
 


### PR DESCRIPTION
<h2>Change Log</h2>
<div id="change-log">
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Fix the CI status badge URL.</li>
  </ul>
</div>
<hr/>

<h2>Description</h2>

- It seems that the original Travis CI status badge URL is broken. Using the GitHub workflows action badge instead.
