### PR TITLE
support php84 (and fix deprecations)

### DIFF
--- a/.github/workflows/static-analyze.yml
+++ b/.github/workflows/static-analyze.yml
@@ -19,7 +19,7 @@ jobs:
         dependencies:
           - "locked"
         php-version:
-          - "8.1"
+          - "8.2"
         operating-system:
           - "ubuntu-latest"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,9 +21,9 @@ jobs:
           - "lowest"
           - "highest"
         php-version:
-          - "8.1"
           - "8.2"
           - "8.3"
+          - "8.4"
         operating-system:
           - "ubuntu-latest"
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "~8.1 || ~8.2 || ~8.3",
+        "php": "~8.1 || ~8.2 || ~8.3 || ~8.4",
         "symfony/translation": "~5.4||~6.4||~7",
         "symfony/yaml": "~5.4||~6.4||~7",
         "aeon-php/calendar": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "~8.1 || ~8.2 || ~8.3 || ~8.4",
+        "php": "~8.2 || ~8.3 || ~8.4",
         "symfony/translation": "~5.4||~6.4||~7",
         "symfony/yaml": "~5.4||~6.4||~7",
         "aeon-php/calendar": "^1.0"

--- a/src/Coduo/PHPHumanizer/Collection/Formatter.php
+++ b/src/Coduo/PHPHumanizer/Collection/Formatter.php
@@ -30,7 +30,7 @@ final class Formatter
      *
      * @param array<string> $collection
      */
-    public function format(array $collection, int $limit = null) : string
+    public function format(array $collection, ?int $limit = null) : string
     {
         $count = \count($collection);
 

--- a/src/Coduo/PHPHumanizer/Collection/Oxford.php
+++ b/src/Coduo/PHPHumanizer/Collection/Oxford.php
@@ -23,7 +23,7 @@ final class Oxford
     /**
      * @param array<string> $collection
      */
-    public function format(array $collection, int $limit = null) : string
+    public function format(array $collection, ?int $limit = null) : string
     {
         return $this->formatter->format($collection, $limit);
     }

--- a/src/Coduo/PHPHumanizer/CollectionHumanizer.php
+++ b/src/Coduo/PHPHumanizer/CollectionHumanizer.php
@@ -20,7 +20,7 @@ final class CollectionHumanizer
     /**
      * @param array<string> $collection
      */
-    public static function oxford(array $collection, int $limit = null, string $locale = 'en') : string
+    public static function oxford(array $collection, ?int $limit = null, string $locale = 'en') : string
     {
         $oxford = new Oxford(
             new Formatter(Builder::build($locale))

--- a/src/Coduo/PHPHumanizer/String/BinarySuffix.php
+++ b/src/Coduo/PHPHumanizer/String/BinarySuffix.php
@@ -34,7 +34,7 @@ final class BinarySuffix
         0 => '# bytes',
     ];
 
-    public function __construct(int $number, string $locale = 'en', int $precision = null)
+    public function __construct(int $number, string $locale = 'en', ?int $precision = null)
     {
         if (!\class_exists(\NumberFormatter::class)) {
             throw new \RuntimeException('Binary suffix converter requires intl extension!');


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>PHP 8.4 support</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Deprecated errors gone</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>
<p>PHP 8.4 Support</p>
<p>TBH it worked but it threw some deprecation errors (see below)</p>
<b>Deprecated</b>:  Coduo\PHPHumanizer\String\BinarySuffix::__construct(): Implicitly marking parameter $precision as nullable is deprecated, the explicit nullable type must be used instead in <b>#REDACTED#\vendor\coduo\php-humanizer\src\Coduo\PHPHumanizer\String\BinarySuffix.php</b> on line <b>37</b><br>